### PR TITLE
Add a landing page at the Pages root

### DIFF
--- a/docs/efficiency-calc/index.html
+++ b/docs/efficiency-calc/index.html
@@ -150,12 +150,6 @@
     text-wrap: balance;
   }
 
-  .standfirst {
-    color: var(--muted);
-    margin: 12px 0 0;
-    max-width: 60ch;
-  }
-
   /* the four HWP angles of one cycle — the unit everything else counts in */
   .cycle-key {
     flex: 0 0 auto;
@@ -723,11 +717,6 @@
     <div class="masthead-text">
       <p class="eyebrow">Keck II &middot; NIRC2 &middot; polarimetry</p>
       <h1>HWP Cycle Time Calculator</h1>
-      <p class="standfirst">
-        Half-wave plate cycling makes NIRC2 polarimetry considerably more expensive than
-        straight imaging. Enter a proposed setup to see the wall-clock cost, the integration
-        you actually keep, and where the rest of the time goes.
-      </p>
     </div>
 
     <!-- the cycle in the order HWP_Rotation_Sequence.sh actually steps it -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,245 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="Web tools published from the NIRC2-Pol operations software repository, for the dual-channel polarimetry mode on Keck II NIRC2.">
+<title>NIRC2-Pol Operations</title>
+
+<style>
+  /* Tokens are kept in step with efficiency-calc/index.html so the two pages
+     read as one site. */
+  :root {
+    --ground:      #E7EAEF;
+    --surface:     #FFFFFF;
+    --surface-sunk:#F1F3F7;
+    --ink:         #12151C;
+    --ink-2:       #3C4453;
+    --muted:       #5B6374;
+    --line:        #D5DAE3;
+    --line-soft:   #E3E7EE;
+    --accent:      #A8341F;
+    --accent-soft: #F6E6E1;
+
+    --font-display: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Charter, Georgia, serif;
+    --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif;
+    --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+    color-scheme: light dark;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ground:      #0D1016;
+      --surface:     #171C24;
+      --surface-sunk:#111620;
+      --ink:         #E3E7EF;
+      --ink-2:       #B7C0CE;
+      --muted:       #8996A8;
+      --line:        #29323F;
+      --line-soft:   #212934;
+      --accent:      #FF7A66;
+      --accent-soft: #2A1A17;
+    }
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--font-ui);
+    font-size: 15px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 56px 20px 72px;
+  }
+
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 10px;
+  }
+
+  h1 {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: clamp(30px, 5vw, 42px);
+    line-height: 1.08;
+    letter-spacing: -0.015em;
+    margin: 0;
+    text-wrap: balance;
+  }
+
+  .standfirst {
+    color: var(--muted);
+    margin: 14px 0 0;
+    max-width: 62ch;
+  }
+
+  h2 {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 600;
+    margin: 44px 0 14px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  /* Each published tool is one card; the list grows as the repo publishes more. */
+  .tool {
+    display: block;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 18px 20px;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .tool:hover { border-color: var(--accent); }
+
+  .tool:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .tool h3 {
+    font-family: var(--font-ui);
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--accent);
+    margin: 0 0 5px;
+  }
+
+  .tool p {
+    color: var(--ink-2);
+    font-size: 14px;
+    margin: 0 0 10px;
+  }
+
+  .tool .path {
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--muted);
+  }
+
+  ul.links {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 9px;
+  }
+
+  ul.links a {
+    color: var(--accent);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+  }
+
+  ul.links span {
+    color: var(--muted);
+    font-size: 13.5px;
+  }
+
+  ul.links .doi {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 11.5px;
+    color: var(--muted);
+    margin-top: 1px;
+  }
+
+  footer {
+    margin-top: 48px;
+    padding-top: 18px;
+    border-top: 1px solid var(--line);
+    font-size: 12.5px;
+    color: var(--muted);
+  }
+
+  footer a { color: var(--accent); }
+</style>
+</head>
+<body>
+
+<div class="wrap">
+
+  <p class="eyebrow">Keck II &middot; NIRC2 &middot; polarimetry</p>
+  <h1>NIRC2-Pol Operations</h1>
+  <p class="standfirst">
+    NIRC2-Pol is a dual-channel polarimetry mode on the Keck II NIRC2 infrared imager. A
+    polarizing beamsplitter separates the incoming light into two orthogonal polarization
+    states, and a half-wave plate modulates the angle of polarization through cycles of four
+    critical angles to recover the linear Stokes components Q and U. These are the web tools
+    published from the operations software repository.
+  </p>
+
+  <h2>Tools</h2>
+
+  <a class="tool" href="efficiency-calc/">
+    <h3>HWP cycle time calculator</h3>
+    <p>
+      Estimate total elapsed time, on-sky integration and efficiency for a proposed observing
+      setup, with a breakdown of where the overhead goes.
+    </p>
+    <span class="path">efficiency-calc/</span>
+  </a>
+
+  <h2>Documentation</h2>
+
+  <ul class="links">
+    <li>
+      <a href="https://doi.org/10.5281/zenodo.20737935">NIRC2 Polarimetry Operations Guide</a>
+      <span>&mdash; full technical details of the mode, including calibration and on-sky
+        usage. Lewis, Millar-Blanchaer, Zhang &amp; Nguyen.</span>
+      <span class="doi">doi:10.5281/zenodo.20737935</span>
+    </li>
+  </ul>
+
+  <h2>Related code</h2>
+
+  <ul class="links">
+    <li>
+      <a href="https://github.com/UCSB-Exoplanet-Polarimetry-Lab/NIRC2Pol-Ops">NIRC2Pol-Ops</a>
+      <span>&mdash; observing and calibration scripts (this repository)</span>
+    </li>
+    <li>
+      <a href="https://github.com/UCSB-Exoplanet-Polarimetry-Lab/NIRC2Pol-DPP">NIRC2Pol-DPP</a>
+      <span>&mdash; data processing pipeline</span>
+    </li>
+    <li>
+      <a href="https://github.com/UCSB-Exoplanet-Polarimetry-Lab/pyPolCal">pyPolCal</a>
+      <span>&mdash; instrumental polarization calibration</span>
+    </li>
+    <li>
+      <a href="https://doi.org/10.5281/zenodo.20752256">pyMuellerMat</a>
+      <span>&mdash; Mueller matrix modelling. Millar-Blanchaer, Lucas &amp; Park.</span>
+      <span class="doi">doi:10.5281/zenodo.20752256</span>
+    </li>
+  </ul>
+
+  <footer>
+    NIRC2-Pol was developed as part of the Precision Calibration Unit (PCU2) project on Keck II.
+    To acknowledge use of the mode, please cite Lewis et al. in prep &mdash; see the
+    <a href="https://github.com/UCSB-Exoplanet-Polarimetry-Lab/NIRC2Pol-Ops">repository README</a>
+    for the current citation.
+  </footer>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Gives /NIRC2Pol-Ops/ an index instead of a 404, listing what the repo publishes and pointing at the operations guide (doi:10.5281/zenodo.20737935), pyMuellerMat (doi:10.5281/zenodo.20752256) and the sibling code repos.

Also drops the introductory paragraph from the calculator, which the landing page now covers.