### PR TITLE
Tidy the Target card on the exposure time calculator

### DIFF
--- a/docs/exposure-time-calc/index.html
+++ b/docs/exposure-time-calc/index.html
@@ -219,7 +219,9 @@
     color: var(--ink-2);
   }
 
-  .field .hint {
+  /* Not scoped to .field: several hints sit directly in a fieldset or in an
+     .adv-body, and scoping left those rendering at full body size. */
+  .hint {
     font-size: 11.5px;
     color: var(--muted);
     line-height: 1.4;
@@ -606,8 +608,6 @@
         <p class="card-note">Every value updates the readout immediately.</p>
 
         <fieldset class="fieldset">
-          <legend>Source</legend>
-
           <div class="field">
             <label for="preset">Preset companion</label>
             <div class="control">
@@ -796,8 +796,6 @@
               <span class="unit">%</span>
             </div>
             <div class="presets" id="polPresets"></div>
-            <p class="hint">Directly imaged companions typically sit below 0.1%. Models predict up
-              to 2% for cloudy, oblate objects.</p>
           </div>
 
           <div class="field">


### PR DESCRIPTION
Drops the polarization fraction hint about typical companion values, and removes the "Source" fieldset legend, which only restated the "Target" card heading directly above it and drew a divider rule under it for no reason.

Also unscopes the .hint rule. It was written as `.field .hint`, but two hints sit directly in a fieldset or in an .adv-body rather than in a .field -- the Strehl note and the residual starlight note -- so they were rendering at full 15px body size instead of 11.5px.